### PR TITLE
feat(normalize-url): using normalize-url to strip tracking codes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,17 +3,25 @@ const environment = require('./bin/assert-env');
 
 const pinboardService = require('./service/pinboard-service');
 const crawlerService = require('./service/crawler-service');
+const { removeTrackers } = require('./utils');
 
 environment.assertAll({ dotenv, services: ['pinboard'] });
 
-const urls = [
-];
+const urls = [];
 
-for (let articleUrl of urls) {
+for (let url of urls) {
+    const articleUrl = removeTrackers(url);
     crawlerService.fetchTitle(articleUrl).then((title) => {
         return pinboardService.addUrl({ articleUrl, title })
-    }).then(info => {
-        console.log('Success', info);
+    }).then(body => {
+        if (body.result_code !== 'done') {
+            console.log('Failure', {
+                body,
+                articleUrl,
+                status: info.status,
+                statusText: info.statusText
+            });
+        }
     }).catch(err => {
         console.log('Error', {
             status: err.status,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cron": "^1.7.1",
     "dotenv": "^7.0.0",
     "node-fetch": "^2.4.1",
+    "normalize-url": "6.1.0",
     "request": "^2.88.2",
     "twitter": "^1.7.1"
   },

--- a/service/crawler-service.js
+++ b/service/crawler-service.js
@@ -1,15 +1,28 @@
-var request = require('request');
-var cheerio = require('cheerio');
+const request = require('request');
+const cheerio = require('cheerio');
 
+/**
+ * Attempts to fetch title of a page,
+ * incase of failure uses URL of the page to
+ * be the title
+ * @param {*} url 
+ * @returns 
+ */
 function fetchTitle(url) {
     return new Promise((resolve, reject) => {
         request(url, function (error, response, body) {
-
             if (error || response.statusCode !== 200) {
-                return resolve('title is missing');
+                return resolve(encodeURI(url));
             }
+
             var $ = cheerio.load(body);
-            return resolve($("head > title").text().trim());
+
+            // if the title doesnt exist use URL
+            title = resolve($("head > title").text().trim() || url);
+
+            // for cases if the title has unescapeable characters
+            // we can use encode URL
+            return encodeURI(fetchTitle);
         });
     });
 }

--- a/service/pinboard-service.js
+++ b/service/pinboard-service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fetch = require("node-fetch");
 
 const {
@@ -49,12 +47,13 @@ function getTags({ title, entities, tweetBy }) {
  */
 
 function addUrl({ articleUrl, title, entities, tweetBy }) {
+  const tags = getTags({ title, entities, tweetBy });
   const queryParams = [
     'format=json',
     `auth_token=${PINBOARD_API_TOKEN}`,
     `url=${articleUrl}`,
     `description=${title}`,
-    `tags=${getTags({ title, entities, tweetBy })}`
+    ...(tags.length > 0 ? `tags=${tags}` : [])
   ];
   return fetch(encodeURI(`https://api.pinboard.in/v1/posts/add?${queryParams.join('&')}`), {
     method: 'POST',
@@ -62,7 +61,7 @@ function addUrl({ articleUrl, title, entities, tweetBy }) {
       Accept: 'application/json',
       'Content-Type': 'application/json'
     }
-  });
+  }).then(res => res.json());
 }
 
 module.exports = {

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,7 @@
+const timeUtils = require('./time-utils');
+const urlUtils = require('./url-utils');
+
+module.exports = {
+    ...timeUtils,
+    ...urlUtils,
+};

--- a/utils/url-utils.js
+++ b/utils/url-utils.js
@@ -1,0 +1,17 @@
+const normalizeUrl = require('normalize-url');
+
+function removeTrackers(url) {
+    return normalizeUrl(url, {
+        stripHash: true,
+        removeQueryParameters: [
+            'ref',
+            'utm_campaign',
+            'utm_medium',
+            'utm_source'
+        ]
+    });
+}
+
+module.exports = {
+    removeTrackers,
+};


### PR DESCRIPTION
This PR removes following items before saving them to pinboard 
- `#` - unnecessary component in medium URL structure.
- `utm_source`, `utm_medium`, `utm_campaign`, `ref` tracking codes.