### PR TITLE
feat(telegram): adding support for posting links directly from telegram to pinboard 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,15 +1,16 @@
 # Twitter values
 # It will be in https://developer.twitter.com/en/apps
 
-TWITTER_CONSUMER_KEY=<value from Twitter>
-TWITTER_CONSUMER_SECRET=<value from Twitter>
-TWITTER_ACCESS_TOKEN_KEY=<value from Twitter>
-TWITTER_ACCESS_TOKEN_KEY_SECRET=<value from Twitter>
+TWITTER_CONSUMER_KEY=
+TWITTER_CONSUMER_SECRET=
+TWITTER_ACCESS_TOKEN_KEY=
+TWITTER_ACCESS_TOKEN_KEY_SECRET=
 
 # My twitter handle
 # eg 'nodejs' is the handle of 'https://twitter.com/nodejs' account
 
-TWITTER_SCREEN_NAME=handle name without @
+# handle name without @
+TWITTER_SCREEN_NAME=
 
 # Pinboard
 # It will be in https://pinboard.in/settings/password

--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,9 @@ TWITTER_SCREEN_NAME=
 # It will be in https://pinboard.in/settings/password
 
 PINBOARD_API_TOKEN=<value from Pinboard.in>
+
+# Telegram
+# the Telegram token you received from @BotFather after creating the Bot
+TELEGRAM_BOT_TOKEN=
+# Your telegram username to restrict the bot to accept the commands received only from you.
+TELEGRAM_USER_NAME=

--- a/bin/assert-env.js
+++ b/bin/assert-env.js
@@ -12,11 +12,15 @@ const ATTRIBUTES = {
     'TWITTER_SCREEN_NAME',
   ],
   pinboard: ['PINBOARD_API_TOKEN'],
+  telegram: [
+    'TELEGRAM_BOT_TOKEN',
+    'TELEGRAM_USER_NAME'
+  ]
 };
 
 function assertTokens(services) {
   const requiredAttributes = services.flatMap(service => ATTRIBUTES[service]);
-  
+
   for (let attribute of requiredAttributes) {
     if (!process.env[attribute]) {
       console.log(`Please set value for ${chalk.red(attribute)}`);

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const timeUtils = require('./utils/time-utils');
 
 const environment = require('./bin/assert-env');
 
-environment.assertAll({ dotenv, services: ['twitter', 'pinboard'] });
+environment.assertAll({ dotenv, services: ['twitter', 'pinboard', 'telegram'] });
 
 const twitterService = require('./service/twitter-service');
 const pinboardService = require('./service/pinboard-service');
+const telegramService = require('./service/telegram-bot-service');
 
 function processTweet(tweet) {
   return pinboardService.addUrl(tweet).then(() => {
@@ -34,3 +35,5 @@ new CronJob('0 */1 * * * *', () => { // runs at 1st second of every minute
   console.log('Polling Twitter => ', timeUtils.getHumanReadableTime());
 
 }, null, true);
+
+telegramService.listen();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cron": "^1.7.1",
     "dotenv": "^7.0.0",
     "node-fetch": "^2.4.1",
+    "node-telegram-bot-api": "^0.58.0",
     "normalize-url": "6.1.0",
     "request": "^2.88.2",
     "twitter": "^1.7.1"

--- a/service/telegram-bot-service.js
+++ b/service/telegram-bot-service.js
@@ -1,0 +1,42 @@
+const TelegramBot = require('node-telegram-bot-api');
+
+const { TELEGRAM_BOT_TOKEN, TELEGRAM_USER_NAME } = process.env;
+
+const pinboardService = require('./pinboard-service');
+
+const bot = new TelegramBot(TELEGRAM_BOT_TOKEN, { polling: true });
+
+function listen() {
+  bot.on('message', (msg) => {
+    const { message_id: originalMessageId, chat: { id: chatId }, from: { username }, entities = [], text } = msg;
+
+    // to restrict the Bot the accept the command
+    // from the creator of the Bot
+    if (username !== TELEGRAM_USER_NAME) {
+      bot.sendMessage(chatId, 'Fork https://github.com/sridharrajs/pin-tweet and create your own Telegram Bot');
+      return;
+    }
+
+    const links = entities.filter(entity => entity.type === 'url')
+    if (links.length > 0) {
+      for (const entity of links) {
+        const { offset, length } = entity;
+        const url = text.slice(offset, offset + length);
+
+        pinboardService.addUrl({
+          articleUrl: url,
+          title: text
+        });
+
+        bot.sendMessage(chatId, `bookmarked ✅`, {
+          reply_to_message_id: originalMessageId
+        });
+      }
+      return;
+    }
+
+    bot.sendMessage(chatId, 'No URL found in text');
+  });
+}
+
+module.exports = { listen }

--- a/telegram-message.sample.json
+++ b/telegram-message.sample.json
@@ -1,0 +1,43 @@
+{
+    "message_id": 88,
+    "from": {
+        "id": 111049190,
+        "is_bot": false,
+        "first_name": "firstname",
+        "last_name": "lastname",
+        "username": "YOUR_USERNAME",
+        "language_code": "en"
+    },
+    "chat": {
+        "id": 111049190,
+        "first_name": "firstname",
+        "last_name": "lastname",
+        "username": "YOUR_USERNAME",
+        "type": "private"
+    },
+    "date": 1661253604,
+    "forward_from": {
+        "id": 134651616,
+        "is_bot": false,
+        "first_name": "somebody"
+    },
+    "forward_date": 1661237719,
+    "text": "https://www.nasa.gov/mission_pages/chandra/news/new-nasa-black-hole-sonifications-with-a-remix.html\nhttps://www.gingerbill.org/article/2021/02/01/the-essence-of-programming\nhttps://vimeo.com/215418110",
+    "entities": [
+        {
+            "offset": 0,
+            "length": 99,
+            "type": "url"
+        },
+        {
+            "offset": 100,
+            "length": 72,
+            "type": "url"
+        },
+        {
+            "offset": 173,
+            "length": 27,
+            "type": "url"
+        }
+    ]
+}


### PR DESCRIPTION
**Problem:**
Adding links from FOSSUnited [telegram group](https://t.me/joinchat/RUh3Qb2fb1k0pQbO) to pinboard _individual_ is _painful_.

**Solution:**
Create a telegram bot and bulk forward the messages which has link in them. 

**Steps for integration**

Step 1: 
[Create a telegram bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot) and fill the values in `.env` file.

Step 2:
Select all the messages that has link in them and forward it to bot created in step 1.
![Screenshot_20220823-173611-370](https://user-images.githubusercontent.com/1156953/186156068-df45f322-956f-4f10-a999-fc160ef2fb27.png)

Step 3:
Once forwarded, the bot will post them to your pinboard account on behalf of you.
![Screenshot_20220823-174017-521](https://user-images.githubusercontent.com/1156953/186156957-84f61c6a-def4-40e3-afd9-041336803d92.png)


