### PR TITLE
fix(telegram): inform the user when bookmarking fails

### DIFF
--- a/service/telegram-bot-service.js
+++ b/service/telegram-bot-service.js
@@ -26,11 +26,16 @@ function listen() {
         pinboardService.addUrl({
           articleUrl: url,
           title: text
+        }).then(() => {
+          bot.sendMessage(chatId, `bookmarked ✅`, {
+            reply_to_message_id: originalMessageId
+          });
+        }).catch(() => {
+          bot.sendMessage(chatId, 'Failed ❌', {
+            reply_to_message_id: originalMessageId
+          });
         });
 
-        bot.sendMessage(chatId, `bookmarked ✅`, {
-          reply_to_message_id: originalMessageId
-        });
       }
       return;
     }


### PR DESCRIPTION
This PR handles the error case, if the bookmarking fails. It responds back to the message with `Failed ❌` message.