### PR TITLE
refactor: tagging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,18 @@
 # Changelog
 
+# 2.0.0
+* refactor: tagging [#14](https://github.com/sridharrajs/pin-tweet/pull/14)
+
 ## 1.2.0
-* docs: adding changelog.md
-* feat: add support for mastodon (#12)
+* docs: adding changelog.md [#13](https://github.com/sridharrajs/pin-tweet/pull/13)
+* feat: add support for mastodon [#12](https://github.com/sridharrajs/pin-tweet/pull/12)
 
 ## 1.1.0
 
-* fix(telegram): inform user when bookmarking fails (#11)
-* tech: replace node-fetch with axios (#10)
-* feat(telegram): adding support for posting links directly from telegram to pinboard (#9)
-* feat(normalize-url): using normalize-url to strip tracking codes
+* fix(telegram): inform user when bookmarking fails [#11](https://github.com/sridharrajs/pin-tweet/pull/11)
+* tech: replace node-fetch with axios [#10](https://github.com/sridharrajs/pin-tweet/pull/10)
+* feat(telegram): adding support for posting links directly from telegram to pinboard [#9](https://github.com/sridharrajs/pin-tweet/pull/9)
+* feat(normalize-url): using normalize-url to strip tracking codes [#8](https://github.com/sridharrajs/pin-tweet/pull/8)
 
 ## 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pin-tweet",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A program that moves your favourited tweets to pinboard",
   "main": "index.js",
   "dependencies": {

--- a/rules.sample.json
+++ b/rules.sample.json
@@ -3,13 +3,9 @@
     "react": "react",
     "javascript": "js",
     "graphql": "graphql",
-    "node": "node"
-  },
-  "urls": {
+    "node": "node",
     "youtube.com": "video",
-    "kencdodds.com": "react"
-  },
-  "screen_name": {
+    "kencdodds.com": "react",
     "dvassallo": "dvassallo",
     "kentcdodds": "kentcdodds"
   }

--- a/service/pinboard-service.js
+++ b/service/pinboard-service.js
@@ -1,42 +1,9 @@
 const axios = require('axios');
 
-const {
-  text: textRules,
-  urls: urlRules,
-  screen_name: screenNameRules
-} = require('../rules.json');
+const { getTags } = require('./tagging-service');
 
 const { PINBOARD_API_TOKEN } = process.env;
 
-function getTags({ title, entities, tweetBy }) {
-  const tags = [];
-
-  const text = title.toLowerCase();
-  // text rules based on the content
-  for (const word of Object.keys(textRules)) {
-    if (text.includes(word)) {
-      tags.push(textRules[word]);
-    }
-  }
-
-  if (entities && entities.urls) {
-    // url rules based on the media url that the tweet has
-    for (const url of entities.urls) {
-      const { display_url: displayUrl } = url;
-      for (const urlRule of Object.keys(urlRules)) {
-        if (displayUrl.includes(urlRule)) {
-          tags.push(urlRules[urlRule]);
-        }
-      }
-    }
-  }
-
-  if (Object.keys(screenNameRules).includes(tweetBy)) {
-    tags.push(screenNameRules[tweetBy]);
-  }
-
-  return tags;
-}
 
 /**
  * Ref https://pinboard.in/api#posts_add
@@ -46,8 +13,8 @@ function getTags({ title, entities, tweetBy }) {
  * @returns {Promise<Response>}
  */
 
-function addUrl({ articleUrl, title, entities, tweetBy }) {
-  const tags = getTags({ title, entities, tweetBy });
+function addUrl({ articleUrl, title, entities }) {
+  const tags = getTags({ articleUrl, title, entities });
   const queryParams = [
     'format=json',
     `auth_token=${PINBOARD_API_TOKEN}`,

--- a/service/pinboard-service.js
+++ b/service/pinboard-service.js
@@ -24,7 +24,7 @@ function addUrl({ articleUrl, title, entities }) {
   ];
 
   return axios.post(`https://api.pinboard.in/v1/posts/add?${queryParams.join('&')}`).then(res => {
-    return res.data;
+    return { ...res.data, tags };
   });
 }
 

--- a/service/tagging-service.js
+++ b/service/tagging-service.js
@@ -23,8 +23,6 @@ function getTags({ articleUrl, title, entities }) {
     }
   }
 
-  console.log(tags);
-
   return tags;
 }
 

--- a/service/tagging-service.js
+++ b/service/tagging-service.js
@@ -1,0 +1,31 @@
+const { text: textRules } = require('../rules.json');
+
+function getTags({ articleUrl, title, entities }) {
+  const tags = [];
+
+  for (const [word, tag] of Object.entries(textRules)) {
+    const isUrlMatching = new RegExp(word, 'gi').test(articleUrl);
+    const isTitleMatching = new RegExp(word, 'gi').test(title);
+    if (isTitleMatching || isUrlMatching) {
+      tags.push(tag);
+    }
+  }
+
+  if (entities && entities.urls) {
+    // url rules based on the media url that the tweet has
+    for (const url of entities.urls) {
+      const { expanded_url: linkURL } = url;
+      for (const [word, tag] of Object.entries(textRules)) {
+        if (new RegExp(word, 'gi').test(linkURL)) {
+          tags.push(tag);
+        }
+      }
+    }
+  }
+
+  console.log(tags);
+
+  return tags;
+}
+
+module.exports = { getTags }

--- a/service/telegram-bot-service.js
+++ b/service/telegram-bot-service.js
@@ -26,8 +26,8 @@ function listen() {
         pinboardService.addUrl({
           articleUrl: url,
           title: text
-        }).then(() => {
-          bot.sendMessage(chatId, `bookmarked ✅`, {
+        }).then((bookmark) => {
+          bot.sendMessage(chatId, `bookmarked ✅ with - [${bookmark.tags.join(',')}] tags`, {
             reply_to_message_id: originalMessageId
           });
         }).catch(() => {


### PR DESCRIPTION
This PR does the following things
- refactors tagging to be generic instead of being twitter specific.
- considers `articleURL` and `title` for tagging.
- displays the bookmarked tags in telegram acknowledgement message.
- version bump `2.0.0` since `rules.json` is not backward compatible with the previous version.